### PR TITLE
Fixed syntax error in picom config

### DIFF
--- a/.config/picom/picom.conf
+++ b/.config/picom/picom.conf
@@ -10,5 +10,5 @@ opacity-rule = [
   "90:class_g = 'St' && focused",
   "85:class_g = 'St' && !focused",
   "90:class_g = 'tabbed' && focused",
-  "85:class_g = 'tabbed' && !focused",
+  "85:class_g = 'tabbed' && !focused"
 ];


### PR DESCRIPTION
This syntax error prevented picom from propertly starting when using Gentoo